### PR TITLE
⚡️Feature: pass information through authentication process

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,5 +35,5 @@ exports.ApplicationCredential = require('./models/application-credential')(
 exports.UserIdentity.autoAttach = 'db';
 exports.UserCredential.autoAttach = 'db';
 exports.ApplicationCredential.autoAttach = 'db';
-
+exports.utils = require('./models/utils');
 exports.PassportConfigurator = require('./passport-configurator');

--- a/lib/models/user-identity.js
+++ b/lib/models/user-identity.js
@@ -210,10 +210,6 @@ function UserIdentity(UserIdentity) {
           query = {username: userObj.username};
         }
 
-        if(userObj.provider == 'google' || userObj.provider == 'outlook') {
-          query = { email: userObj.email };
-        }
-
         userModel.findOrCreate({where: query}, userObj, function(err, user) {
           if (err) {
             return cb(err);

--- a/lib/models/user-identity.js
+++ b/lib/models/user-identity.js
@@ -67,27 +67,13 @@ function UserIdentity(UserIdentity) {
         '@loopback.' +
         (profile.provider || provider) +
         '.com';
-
-      /*
-        If the social provider is either google/outlook, we'll create a loopback user by email
-      */
-      var email = provider === 'ldap' || (provider == 'google' || provider == 'outlook') ? profileEmail : generatedEmail;
+      var email = provider === 'ldap' ? profileEmail : generatedEmail;
       var username = provider + '.' + (profile.username || profile.id);
       password = utils.generateKey('password');
-
-      if(provider == 'google' || provider == 'outlook') {
-        userObj = {
-          password: password,
-          provider: provider
-        }
-      } else {
-        userObj = {
-          username: username,
-          password: password,
-          provider: provider
-        };
-      }
-
+      userObj = {
+        username: username,
+        password: password,
+      };
       if (email) {
         userObj.email = email;
       }

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -617,18 +617,14 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
       session: session,
     }, options.authOptions)));
   } else {
-      self.app.get(authPath, (req, res, next) => {
-        passport.authenticate(name, _.defaults({
+    self.app.get(authPath, (req, res, next) => {
+      passport.authenticate(name, _.defaults({
         scope: scope,
         state: req.query.state,
         session: session,
-      }, options.authOptions))(req, res, next);
+        }, options.authOptions)
+      )(req, res, next);
     });
-
-    self.app.get(authPath, passport.authenticate(name, _.defaults({
-      scope: scope,
-      session: session,
-    }, options.authOptions)));
   }
 
   /*!

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -266,11 +266,6 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
       (link ? '/link/account' : '/auth/account');
   };
 
-  var customSuccessRedirect = function(req, info) {
-    const url = options.successRedirect;
-    return appendAccessToken(url, info.accessToken);
-  };
-
   var appendAccessToken = function(url, accessToken) {
     if (!accessToken) {
       return url;
@@ -589,21 +584,9 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
       } else {
         if (info && info.accessToken) {
           if (!!options.json) {
-            info.user = user;
-            req.information = {info: info, user: user};
-
-            console.log('Information bundle: ' + JSON.stringify(req.information));
-            let redirect = customSuccessRedirect(req, info);
-            console.log('Redirect URL: ' + redirect);
-            return res.redirect(redirect);
-          } else {
-            res.cookie('access_token', info.accessToken.id, {
-              signed: req.signedCookies ? true : false,
-              maxAge: 1000 * info.accessToken.ttl,
-            });
-            res.cookie('userId', user.id.toString(), {
-              signed: req.signedCookies ? true : false,
-              maxAge: 1000 * info.accessToken.ttl,
+            return res.json({
+              'access_token': info.accessToken.id,
+              userId: user.id,
             });
 
             return res.redirect(successRedirect(req, info.accessToken));

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -588,10 +588,18 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
               'access_token': info.accessToken.id,
               userId: user.id,
             });
-
-            return res.redirect(successRedirect(req, info.accessToken));
+          } else {
+            res.cookie('access_token', info.accessToken.id, {
+              signed: req.signedCookies ? true : false,
+              maxAge: 1000 * info.accessToken.ttl,
+            });
+            res.cookie('userId', user.id.toString(), {
+              signed: req.signedCookies ? true : false,
+              maxAge: 1000 * info.accessToken.ttl,
+            });
           }
         }
+        return res.redirect(successRedirect(req, info.accessToken));
       }
     })(req, res, next);
   };

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -634,6 +634,14 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
       session: session,
     }, options.authOptions)));
   } else {
+      self.app.get(authPath, (req, res, next) => {
+        passport.authenticate(name, _.defaults({
+        scope: scope,
+        state: req.query.state,
+        session: session,
+      }, options.authOptions))(req, res, next);
+    });
+
     self.app.get(authPath, passport.authenticate(name, _.defaults({
       scope: scope,
       session: session,


### PR DESCRIPTION
For frontends to be able specifying the `successRedirect` url, `passport` needs to pass the `url` choosen by the client throughout the whole auth process.

To persist that info we can leverage `OAuth2 state` parameter (generic explaination [here](https://auth0.com/docs/protocols/oauth2/oauth-state))